### PR TITLE
:sparkles: #62 LockScreen 위젯 추가

### DIFF
--- a/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyMaskIndexWidget.swift
+++ b/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyMaskIndexWidget.swift
@@ -18,15 +18,41 @@ struct KloudyMaskIndexWidget: Widget {
         }
         .configurationDisplayName("구르미 날씨 지수 위젯 목록")
         .description("원하는 날씨의 위젯을 골라주세요.")
-        .supportedFamilies([.systemSmall])
+        .supportedFamilies([.systemSmall, .accessoryCircular])
     }
 }
 
 struct KloudyMaskIndexWidgetEntryView: View {
     var entry: Provider.Entry
+    @Environment(\.widgetFamily) var family: WidgetFamily
+    
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            KloudyMaskSystemSmallWidgetView(entry: entry)
+        case .accessoryCircular:
+            KloudyMaskAccessoryCircularWidgetView(entry: entry)
+        default:
+            KloudyMaskSystemSmallWidgetView(entry: entry)
+        }
+    }
+}
 
+struct KloudyMaskSystemSmallWidgetView: View {
+    var entry: Provider.Entry
+    
     var body: some View {
         Text("\(String(entry.configuration.WidgetLocaion ?? ""))시의 ")
         Text("마스크 지수")
     }
 }
+
+struct KloudyMaskAccessoryCircularWidgetView: View {
+    var entry: Provider.Entry
+    
+    var body: some View {
+        Text("현재 지역의")
+        Text("마스크 지수")
+    }
+}
+

--- a/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyUmbrellaIndexWidget.swift
+++ b/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyUmbrellaIndexWidget.swift
@@ -18,15 +18,40 @@ struct KloudyUmbrellaIndexWidget: Widget {
         }
         .configurationDisplayName("구르미 날씨 지수 위젯 목록")
         .description("원하는 날씨의 위젯을 골라주세요.")
-        .supportedFamilies([.systemSmall])
+        .supportedFamilies([.systemSmall, .accessoryCircular])
     }
 }
 
 struct KloudyUmbrellaIndexWidgetEntryView: View {
     var entry: Provider.Entry
+    @Environment(\.widgetFamily) var family: WidgetFamily
+    
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            KloudyUmbrellaSystemSmallWidgetView(entry: entry)
+        case .accessoryCircular:
+            KloudyUmbrellaAccessoryCircularWidgetView(entry: entry)
+        default:
+            KloudyUmbrellaSystemSmallWidgetView(entry: entry)
+        }
+    }
+}
 
+struct KloudyUmbrellaSystemSmallWidgetView: View {
+    var entry: Provider.Entry
+    
     var body: some View {
         Text("\(String(entry.configuration.WidgetLocaion ?? ""))시의 ")
+        Text("비 지수")
+    }
+}
+
+struct KloudyUmbrellaAccessoryCircularWidgetView: View {
+    var entry: Provider.Entry
+    
+    var body: some View {
+        Text("현재 지역의")
         Text("비 지수")
     }
 }


### PR DESCRIPTION
### Motivation 
- 잠금 화면을 해제하지않고도 날씨를 확인할 수 있는 기능 필요

### Key Change
- LockScreen 위젯 추가
- `.supportedFamilies`에 `.accessoryCircular, .accessoryRectangular, .accessoryInline`등을 추가하여 락스크린 위젯을 추가할 수 있다.
-  위에 쓰인  `.accessory`로 시작하는 위젯들의 경우 워치에서도 사용할 수 있다.

https://user-images.githubusercontent.com/63584245/197331379-ae273ae1-774c-4d20-956a-065939e54414.MP4



### To Reviewer
- 락스크린 위젯의 경우 위젯 커스텀 기능이 존재하지 않아 바탕화면 위젯처럼 지역 설정이 불가능할 것 같습니다. 락스크린 위젯의 지역 설정 같은 경우에는 앱에서 따로 설정 페이지를 추가하거나 디폴트로 현재지역의 정보를 제공해야될 것 같습니다!
