### PR TITLE
Fix[#177] 테이블뷰가 스크롤될때 검색창을 덮어버리는 문제를 해결했습니다.

### DIFF
--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -47,6 +47,7 @@ class LocationSelectionView: UIViewController {
         bind()
         layout()
         attribute()
+        view.backgroundColor = UIColor.KColor.white
     }
     
     required init?(coder: NSCoder) {
@@ -90,7 +91,7 @@ class LocationSelectionView: UIViewController {
     }
     
     private func layout() {
-        [locationSelectionNavigationView, cancelSearchButton, searchBarBackgroundView, searchBar, tableView, nothingSearchedLocationLabel, magnifyingGlassImage].forEach { view.addSubview($0) }
+        [tableView, locationSelectionNavigationView, cancelSearchButton, searchBarBackgroundView, searchBar, nothingSearchedLocationLabel, magnifyingGlassImage].forEach { view.addSubview($0) }
         
         locationSelectionNavigationView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(62)


### PR DESCRIPTION
### Motivation 
- #177

### Key Change
- locationSelectionView에서 테이블뷰가 스크롤될 때 위로 검색창을 덮어버리는 문제가 있었습니다. 이를 뷰 hierarchy 수정을 통해 해결했습니다.

### To Reviewer
- 아주 간단한 수정이라 바로 머지해도 될 것 같습니다.
