### PR TITLE
Feat[#270] iOS 16 미만일때 LockScreen Widget을 사용하지 못하도록 합니다.

### DIFF
--- a/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyCarWashIndexWidget.swift
+++ b/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyCarWashIndexWidget.swift
@@ -11,6 +11,13 @@ import Intents
 
 struct KloudyCarWashIndexWidget: Widget {
     let kind: String = "KloudyCarWashIndexWidget"
+    private let supportedFamilies:[WidgetFamily] = {
+        if #available(iOSApplicationExtension 16.0, *) {
+            return [.systemSmall, .accessoryCircular]
+        } else {
+            return [.systemSmall]
+        }
+    }()
     
     var body: some WidgetConfiguration {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: KloudyProvider()) { entry in
@@ -18,7 +25,7 @@ struct KloudyCarWashIndexWidget: Widget {
         }
         .configurationDisplayName("구르미 날씨 지수 위젯 목록")
         .description("세차 지수 위젯입니다.")
-        .supportedFamilies([.systemSmall, .accessoryCircular])
+        .supportedFamilies(supportedFamilies)
     }
 }
 

--- a/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyLaundryIndexWidget.swift
+++ b/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyLaundryIndexWidget.swift
@@ -11,6 +11,13 @@ import Intents
 
 struct KloudyLaundryIndexWidget: Widget {
     let kind: String = "KloudyLaundryIndexWidget"
+    private let supportedFamilies:[WidgetFamily] = {
+        if #available(iOSApplicationExtension 16.0, *) {
+            return [.systemSmall, .accessoryCircular]
+        } else {
+            return [.systemSmall]
+        }
+    }()
     
     var body: some WidgetConfiguration {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: KloudyProvider()) { entry in
@@ -18,7 +25,7 @@ struct KloudyLaundryIndexWidget: Widget {
         }
         .configurationDisplayName("구르미 날씨 지수 위젯 목록")
         .description("세탁 지수 위젯입니다.")
-        .supportedFamilies([.systemSmall, .accessoryCircular])
+        .supportedFamilies(supportedFamilies)
     }
 }
 

--- a/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyMaskIndexWidget.swift
+++ b/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyMaskIndexWidget.swift
@@ -11,6 +11,13 @@ import Intents
 
 struct KloudyMaskIndexWidget: Widget {
     let kind: String = "KloudyMaskIndexWidget"
+    private let supportedFamilies:[WidgetFamily] = {
+        if #available(iOSApplicationExtension 16.0, *) {
+            return [.systemSmall, .accessoryCircular]
+        } else {
+            return [.systemSmall]
+        }
+    }()
     
     var body: some WidgetConfiguration {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: KloudyProvider()) { entry in
@@ -18,7 +25,7 @@ struct KloudyMaskIndexWidget: Widget {
         }
         .configurationDisplayName("구르미 날씨 지수 위젯 목록")
         .description("마스크 위젯입니다.")
-        .supportedFamilies([.systemSmall, .accessoryCircular])
+        .supportedFamilies(supportedFamilies)
     }
 }
 

--- a/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyOuterIndexWidget.swift
+++ b/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyOuterIndexWidget.swift
@@ -10,6 +10,13 @@ import Intents
 
 struct KloudyOuterIndexWidget: Widget {
     let kind: String = "KloudyOuterIndexWidget"
+    private let supportedFamilies:[WidgetFamily] = {
+        if #available(iOSApplicationExtension 16.0, *) {
+            return [.systemSmall, .accessoryCircular]
+        } else {
+            return [.systemSmall]
+        }
+    }()
     
     var body: some WidgetConfiguration {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: KloudyProvider()) { entry in
@@ -17,7 +24,7 @@ struct KloudyOuterIndexWidget: Widget {
         }
         .configurationDisplayName("구르미 날씨 지수 위젯 목록")
         .description("겉옷 지수 위젯입니다.")
-        .supportedFamilies([.systemSmall, .accessoryCircular])
+        .supportedFamilies(supportedFamilies)
     }
 }
 

--- a/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyUmbrellaIndexWidget.swift
+++ b/Kloudy/kloudyWidget/KloudyIndexWidget/KloudyUmbrellaIndexWidget.swift
@@ -11,6 +11,13 @@ import Intents
 
 struct KloudyUmbrellaIndexWidget: Widget {
     let kind: String = "KloudyUmbrellaIndexWidget"
+    private let supportedFamilies:[WidgetFamily] = {
+        if #available(iOSApplicationExtension 16.0, *) {
+            return [.systemSmall, .accessoryCircular]
+        } else {
+            return [.systemSmall]
+        }
+    }()
     
     var body: some WidgetConfiguration {
         IntentConfiguration(kind: kind, intent: ConfigurationIntent.self, provider: KloudyProvider()) { entry in
@@ -18,7 +25,7 @@ struct KloudyUmbrellaIndexWidget: Widget {
         }
         .configurationDisplayName("구르미 날씨 지수 위젯 목록")
         .description("우산 위젯입니다..")
-        .supportedFamilies([.systemSmall, .accessoryCircular])
+        .supportedFamilies(supportedFamilies)
     }
 }
 


### PR DESCRIPTION
### Motivation 
- iOS 지원버전을 14로 내리기 위하여

### Key Change
- iOS 16 미만일때 LockScreen Widget을 사용하지 못하도록 합니다.

### To Reviewer
- 화이팅합시다!!!
