### PR TITLE
Fix[#267] 메모리 누수 해결

### DIFF
--- a/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
+++ b/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
@@ -44,6 +44,8 @@ class CheckWeatherView: UIViewController {
         super.viewWillAppear(animated)
 //        지역이 변경될 시 사용할 코드
         dataViewControllers = [UIViewController]()
+        [checkWeatherBasicNavigationView, pageViewController.view, pageControl].forEach { $0.removeFromSuperview() }
+        
         loadWeatherView()
 
         addChild(pageViewController)

--- a/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
+++ b/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
@@ -43,6 +43,9 @@ class CheckWeatherView: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 //        지역이 변경될 시 사용할 코드
+        for i in 0..<dataViewControllers.count {
+            dataViewControllers[i].viewDidDisappear(false)
+        }
         dataViewControllers = [UIViewController]()
         [checkWeatherBasicNavigationView, pageViewController.view, pageControl].forEach { $0.removeFromSuperview() }
         


### PR DESCRIPTION
### Motivation 
- CheckWeatherView에서 다른 뷰를 네비게이션으로 들어갔다가 나올때마다 메모리가 계속 증가하고 있었습니다.

### Key Change

  - **Trouble Situation**
    - navigation pop 할 때마다 `viewWillAppear`가 동작하는데 매번 `addSubview`를 수행함

  - **Trouble Shooting**
    -   `viewWillAppear`안에 `removeFromSuperview`를 넣어 매번 `removeFromSuperview`를 수행하도록 함

```swift
[checkWeatherBasicNavigationView, pageViewController.view, pageControl].forEach { $0.removeFromSuperview() }
```

- **Trouble Situation**
    - navigation pop 할 때마다 `viewWillAppear`가 동작하는데 매번 지역 갯수만큼 페이지뷰 컨트롤러에 다양한 뷰를 담은 `UIViewController`를 추가하는데 이미 뷰가 돌아가고 있는 상황이라   

```swift
dataViewControllers = [UIViewController]()
```

통해 `UIViewController`가 담겨있는 배열을 비워도 메모리에서 내려가지 않고 있음

  - **Trouble Shooting**
    -   `viewWillAppear`안에 페이지뷰컨에 있는 뷰 수만큼 `viewDidDisappear`을 수행하도록 함

```swift
for i in 0..<dataViewControllers.count {
            dataViewControllers[i].viewDidDisappear(false)
        }
```

### To Reviewer
- 이제 얼마 남지 않았습니다! 화이팅합시다 ㅎㅎ
