### PR TITLE
Feat: first cell에 위치 동의 문구 넣기, 클릭시 위치 사용 동의 띄우기

### DIFF
--- a/Kloudy/Kloudy.xcodeproj/project.pbxproj
+++ b/Kloudy/Kloudy.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1131D4D1292D558E00D80547 /* CurrentLocationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1131D4D0292D558E00D80547 /* CurrentLocationTableViewCell.swift */; };
 		113D3E312909817800A72594 /* LocationSelectionNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113D3E302909817800A72594 /* LocationSelectionNavigationView.swift */; };
 		11E34889291CF179006EA966 /* LocationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E34888291CF179006EA966 /* LocationTableViewCell.swift */; };
 		11E3488B2929BD8B006EA966 /* LocationData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E3488A2929BD8B006EA966 /* LocationData.swift */; };
@@ -200,6 +201,7 @@
 		08F092CB60A0B6FEC442CFF7 /* Pods-KloudyTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KloudyTests.debug.xcconfig"; path = "Target Support Files/Pods-KloudyTests/Pods-KloudyTests.debug.xcconfig"; sourceTree = "<group>"; };
 		0F79FF924295D51CF7B36E17 /* Pods_KloudyTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_KloudyTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		10CCD35D32A3178C668CB51D /* Pods-kloudyWidgetExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-kloudyWidgetExtension.debug.xcconfig"; path = "Target Support Files/Pods-kloudyWidgetExtension/Pods-kloudyWidgetExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		1131D4D0292D558E00D80547 /* CurrentLocationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentLocationTableViewCell.swift; sourceTree = "<group>"; };
 		113D3E302909817800A72594 /* LocationSelectionNavigationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSelectionNavigationView.swift; sourceTree = "<group>"; };
 		11E34888291CF179006EA966 /* LocationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationTableViewCell.swift; sourceTree = "<group>"; };
 		11E3488A2929BD8B006EA966 /* LocationData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationData.swift; sourceTree = "<group>"; };
@@ -733,6 +735,7 @@
 			children = (
 				D537D2152907B34900271037 /* LocationSelectionCollectionViewCell.swift */,
 				11E34888291CF179006EA966 /* LocationTableViewCell.swift */,
+				1131D4D0292D558E00D80547 /* CurrentLocationTableViewCell.swift */,
 			);
 			path = LocationSelectionCollectionViewCell;
 			sourceTree = "<group>";
@@ -952,10 +955,6 @@
 				D59C95D8292D450D00A1FEE5 /* carwash_step3.json in Resources */,
 				D59C95E8292D454300A1FEE5 /* mask_step3.png in Resources */,
 				8BC8F80229011DB200EF83AE /* Assets.xcassets in Resources */,
-				D59C95212927D40C00A1FEE5 /* laundry_3.json in Resources */,
-				D59C95252927D40C00A1FEE5 /* laundry_4.json in Resources */,
-				D59C95392927D40C00A1FEE5 /* rain_step1.json in Resources */,
-				D59C953B2927D40C00A1FEE5 /* rain_step4.json in Resources */,
 				11EAFF7A292D41210091F8C7 /* CityInformation_KOR.csv in Resources */,
 				D59C95F3292D455000A1FEE5 /* outer_step4.png in Resources */,
 				D59C95FA292D455D00A1FEE5 /* rain_step2.json in Resources */,
@@ -1007,11 +1006,6 @@
 				D59C957A292A919C00A1FEE5 /* Localizable.strings in Resources */,
 				D59C9579292A919900A1FEE5 /* CityInformation.csv in Resources */,
 				11EAFF7B292D41210091F8C7 /* CityInformation_KOR.csv in Resources */,
-				D59C952C2927D40C00A1FEE5 /* outer_step5.png in Resources */,
-				D59C95462927D40C00A1FEE5 /* mask_step1.png in Resources */,
-				D59C953C2927D40C00A1FEE5 /* rain_step4.json in Resources */,
-				D59C95282927D40C00A1FEE5 /* outer_step2.png in Resources */,
-				D59C95342927D40C00A1FEE5 /* carwash_step1.json in Resources */,
 				D592C993290AED5B00C53F06 /* Lexend-Regular.ttf in Resources */,
 				BA0686A52926502700AB3849 /* Lexend-Light.ttf in Resources */,
 			);
@@ -1149,6 +1143,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1131D4D1292D558E00D80547 /* CurrentLocationTableViewCell.swift in Sources */,
 				2286B45B2925325C003965F2 /* LicenseCellView.swift in Sources */,
 				8BC8F7D229011DB200EF83AE /* CoreDataStack.swift in Sources */,
 				11E3488B2929BD8B006EA966 /* LocationData.swift in Sources */,

--- a/Kloudy/Kloudy/Resource/Localization/en.lproj/Localizable.strings
+++ b/Kloudy/Kloudy/Resource/Localization/en.lproj/Localizable.strings
@@ -384,3 +384,5 @@ Seogwipo-si="Seogwipo-si";
 "데이터는 실시간 관측된 자료이며 측정소 현지 사정이나 데이터의 수신상태에 따라 미수신될 수 있음" = "Real-time observed data: May not be received depending on the local circumstances of the measuring station or the reception status of the data.";
 
 "CityInformation" = "CityInformation";
+
+"위치 동의 " = "Authorize GPS ";

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
@@ -52,7 +52,7 @@ class CurrentLocationTableViewCell: UITableViewCell {
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(agreement, for: .normal)
         button.setImage(arrowImage, for: .normal)
-        button.setTitleColor(UIColor.KColor.gray02, for: .normal)
+        button.setTitleColor(UIColor.KColor.gray01, for: .normal)
         button.titleLabel?.font = UIFont.KFont.lexendMini
         button.setPreferredSymbolConfiguration(.init(pointSize: 10, weight: .regular, scale: .default), forImageIn: .normal)
         button.contentHorizontalAlignment = .center

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import CoreLocation
 
 class CurrentLocationTableViewCell: UITableViewCell {
 
@@ -23,11 +24,14 @@ class CurrentLocationTableViewCell: UITableViewCell {
     var locationName: String = "현재 위치".localized
     static let identifier = "currentCell"
     var indexPath: Int = 0
+    var locationManager = CLLocationManager()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         addView()
         setLayout()
+        self.locationManager.delegate = self
+        agreeButton.addTarget(self, action: #selector(authorizeGPS), for: .touchUpInside)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -83,5 +87,21 @@ class CurrentLocationTableViewCell: UITableViewCell {
         contentView.layer.cornerRadius = contentView.frame.height / 5
         
         contentView.layer.applySketchShadow(color: UIColor.KColor.gray02, alpha: 0.1, x: 0, y: 0, blur: 40, spread: 0)
+    }
+}
+
+extension CurrentLocationTableViewCell: CLLocationManagerDelegate {
+    @objc func authorizeGPS() {
+        let currentStatus = CLLocationManager().authorizationStatus
+        
+        if currentStatus == .notDetermined {
+            self.locationManager.requestAlwaysAuthorization()
+        } else if currentStatus == .restricted || currentStatus == .denied {
+            if let appSettings = URL(string: UIApplication.openSettingsURLString) {
+                UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)
+            }
+        } else {
+            print("--exception--")
+        }
     }
 }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
@@ -1,0 +1,87 @@
+//
+//  CurrentLocationTableViewCell.swift
+//  Kloudy
+//
+//  Created by Seulki Lee on 2022/11/23.
+//
+
+import UIKit
+
+class CurrentLocationTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+    var locationName: String = "현재 위치".localized
+    static let identifier = "currentCell"
+    var indexPath: Int = 0
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        addView()
+        setLayout()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    lazy var locationNameLabel: UILabel = {
+        let label = UILabel()
+        label.configureLabel(text: locationName.localized, font: UIFont.KFont.appleSDNeoBoldMedium, textColor: UIColor.KColor.gray01)
+        return label
+    }()
+    
+    var agreeButton: UIButton = {
+        let button = UIButton()
+        let agreement = "위치 동의 "
+        let arrowImage = UIImage(systemName: "chevron.right")
+        
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(agreement, for: .normal)
+        button.setImage(arrowImage, for: .normal)
+        button.setTitleColor(UIColor.KColor.gray02, for: .normal)
+        button.titleLabel?.font = UIFont.KFont.lexendMini
+        button.setPreferredSymbolConfiguration(.init(pointSize: 10, weight: .regular, scale: .default), forImageIn: .normal)
+        button.contentHorizontalAlignment = .center
+        button.semanticContentAttribute = .forceRightToLeft
+        
+        return button
+    }()
+    
+    private func addView() {
+        [locationNameLabel, agreeButton].forEach() {
+            contentView.addSubview($0)
+        }
+    }
+    
+    private func setLayout() {
+        locationNameLabel.snp.makeConstraints {
+            $0.leading.equalTo(20)
+            $0.centerY.equalToSuperview()
+        }
+        
+        agreeButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        contentView.backgroundColor = UIColor.KColor.white
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8))
+        
+        contentView.layer.cornerRadius = contentView.frame.height / 5
+        
+        contentView.layer.applySketchShadow(color: UIColor.KColor.gray02, alpha: 0.1, x: 0, y: 0, blur: 40, spread: 0)
+    }
+}

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
@@ -46,7 +46,7 @@ class CurrentLocationTableViewCell: UITableViewCell {
     
     var agreeButton: UIButton = {
         let button = UIButton()
-        let agreement = "위치 동의 "
+        let agreement = "위치 동의 ".localized
         let arrowImage = UIImage(systemName: "chevron.right")
         
         button.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
### Motivation 
- #246 

### Key Change
- locationselectionview의 첫 번째 셀을 만들었습니다.
![Simulator Screen Shot - iPhone 14 Pro - 2022-11-23 at 05 12 41](https://user-images.githubusercontent.com/89380341/203416287-89ac0a8d-7af1-432d-987f-e273dc2c97ed.png)
- 해당 셀에서 위치 동의 버튼 클릭시 위치 동의를 띄우게 함수를 셀 파일 내에 구현하였습니다.
![Simulator Screen Shot - iPhone 14 Pro - 2022-11-23 at 05 12 36](https://user-images.githubusercontent.com/89380341/203416331-9940538c-433b-42c9-b098-80bfc269f379.png)


### To Reviewer
- 테스트해보려면 반드시 configureTableView()에서 tableView.register(CurrentLocationTableViewCell.self, forCellReuseIdentifier: "currentCell")를 추가해야 합니다
- cellForRowAt에서 .check일 때
- if indexPath.row == 0 {
                guard let cell = tableView.dequeueReusableCell(withIdentifier: "currentCell", for: indexPath) as? CurrentLocationTableViewCell else {
                    return UITableViewCell()
                }
                return cell
            } else {
                guard let cell = tableView.dequeueReusableCell(withIdentifier: "locationCell", for: indexPath) as? LocationTableViewCell else {
                    return UITableViewCell()
                }
                return cell
            }
코드를 사용하여 테스트해볼 수 있습니다.

