### PR TITLE
Feat[#319] : Location 들의 기상 정보를 서버에 요청하고 모두 불러왔을 때 메인 화면으로 넘어가도록 구현하였습니다.

### DIFF
--- a/Kloudy/Kloudy/Application/AppDelegate.swift
+++ b/Kloudy/Kloudy/Application/AppDelegate.swift
@@ -26,96 +26,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
     
     // 어플리케이션의 런치 프로세스가 끝났을 때 -> Fetch 요청을 보냄, 요청이 끝나고 난 후 메인화면으로 넘어감.
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-//        let currentStatus = CLLocationManager().authorizationStatus
-//        
-//        let locations = CoreDataManager.shared.fetchLocations()
-//        weathers = [Weather](repeating: dummyData , count: locations.count + 1)
-//        print(locations)
-//        
-//        if locations.count == 0 {
-//            if (currentStatus == .restricted || currentStatus == .notDetermined || currentStatus == .denied) {
-//                CityWeatherNetwork().fetchCityWeather(code: "1111000000")
-//                    .subscribe { event in
-//                        switch event {
-//                        case .success(let data):
-//                            self.weathers.append(data)
-//                        case .failure(let error):
-//                            print("Error: ", error)
-//                        }
-//                    }
-//                    .disposed(by: disposeBag)
-//                CoreDataManager.shared.saveLocation(code: "1111000000", city: "Jongno-gu", province: "Seoul", sequence: CoreDataManager.shared.countLocations(), indexArray: ["rain", "mask", "laundry", "car", "outer"])
-//            } else {
-//                let XY = LocationManager.shared.requestNowLocationInfo()
-//                let nowLocation = FetchWeatherInformation.shared.getLocationInfoByXY(x: XY[0], y: XY[1])
-//                guard let nowLocation = nowLocation else { return true }
-//                
-//                CityWeatherNetwork().fetchCityWeather(code: nowLocation.code)
-//                    .subscribe { event in
-//                        switch event {
-//                        case .success(let data):
-//                            self.weathers[0] = data
-//                        case .failure(let error):
-//                            print("Error: ", error)
-//                        }
-//                    }
-//                    .disposed(by: disposeBag)
-//            }
-//        }
-//        else {
-////            loadLocation()
-//            if (currentStatus == .restricted || currentStatus == .notDetermined || currentStatus == .denied) {
-//                for index in locations.indices {
-//                    CityWeatherNetwork().fetchCityWeather(code: locations[index].code ?? "")
-//                        .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .default))
-//                        .subscribe { event in
-//                            switch event {
-//                            case .success(let data):
-//                                DispatchQueue.main.async {
-//                                    self.weathers[index + 1] = data
-//                                }
-//                            case .failure(let error):
-//                                print("Error: ", error)
-//                            }
-//                        }
-//                        .disposed(by: disposeBag)
-//                }
-//            } else {
-//                let XY = LocationManager.shared.requestNowLocationInfo()
-//                let nowLocation = FetchWeatherInformation.shared.getLocationInfoByXY(x: XY[0], y: XY[1])
-//                guard let nowLocation = nowLocation else { return true }
-//                
-//                CityWeatherNetwork().fetchCityWeather(code: nowLocation.code)
-//                    .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .default))
-//                    .subscribe { event in
-//                        switch event {
-//                        case .success(let data):
-//                            DispatchQueue.main.async {
-//                                self.weathers[0] = data
-//                            }
-//                        case .failure(let error):
-//                            print("Error: ", error)
-//                        }
-//                    }
-//                    .disposed(by: disposeBag)
-//                
-//                for index in locations.indices {
-//                    CityWeatherNetwork().fetchCityWeather(code: locations[index].code ?? "")
-//                        .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .default))
-//                        .subscribe { event in
-//                            switch event {
-//                            case .success(let data):
-//                                DispatchQueue.main.async {
-//                                    self.weathers[index + 1] = data
-//                                }
-//                            case .failure(let error):
-//                                print("Error: ", error)
-//                            }
-//                        }
-//                        .disposed(by: disposeBag)
-//                }
-//            }
-//        }
         return true
     }
     
@@ -138,31 +48,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
     
-    func loadLocation() {
-        let myLocations = CoreDataManager.shared.fetchLocations()
-//        for
-        for locationIndex in myLocations.indices {
-            // 지역 값이 뭔가 잘못된 것이 들어왔다면 끝내야함
-            guard let province = myLocations[locationIndex].province else { return }
-            guard let city = myLocations[locationIndex].city else { return }
-            FetchWeatherInformation.shared.startLoad(province:province, city: city) { response in
-                self.weathers[locationIndex + 1] = response
-            }
-            
-//            CityWeatherNetwork().fetchCityWeather(code: myLocations[locationIndex].code ?? "")
-            
-        let currentStatus = CLLocationManager().authorizationStatus
-            if currentStatus == .authorizedWhenInUse || currentStatus == .authorizedAlways {
-                // 현재 지역의 위도 경도로 기상청에서 제공하는 XY값을 계산 -> XY값으로 현재 지역정보 반환 후 요청을 보냄.
-                let XY = LocationManager.shared.requestNowLocationInfo()
-                let nowLocation = FetchWeatherInformation.shared.getLocationInfoByXY(x: XY[0], y: XY[1])
-                guard let nowLocation = nowLocation else { return }
-                FetchWeatherInformation.shared.startLoad(province: nowLocation.province, city: nowLocation.city) { response in
-                    self.weathers[0] = response
-                }
-            }
-        }
-    }
     // MARK: - Core Data stack
     
     lazy var persistentContainer: NSPersistentCloudKitContainer = {
@@ -204,20 +89,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, CLLocationManagerDelegate
                 // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
                 let nserror = error as NSError
                 fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-    
-    func loadNowLocationWeather(currentProvince: String, currentCity: String) {
-        print([currentProvince, currentCity])
-        let nowLocationInfo = FetchWeatherInformation.shared.getLocationInfo(province: currentProvince, city: currentCity)
-        
-        // 잘못된 도시 정보를 요청할 수 있음.
-        if let nowLocation = nowLocationInfo {
-            let province = nowLocation.province
-            let city = nowLocation.city
-            FetchWeatherInformation.shared.startLoad(province:province, city: city) { response in
-                self.weathers.append(response)
             }
         }
     }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -174,7 +174,7 @@ class LocationSelectionView: UIViewController {
             locationFromCoreData = CoreDataManager.shared.fetchLocations()
         }
         changeCancelButtonState(isSearching)
-//        tableView.reloadData()
+        tableView.reloadData()
     }
     
     private func changeCancelButtonState(_ isSearching: Bool) {

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -482,19 +482,19 @@ extension LocationSelectionView: UITableViewDropDelegate {
     }
     
     // 셀 위치 변경 함수
-//    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-//
-//        // +1로 해줘야할듯
-//        let itemMove = locationList[sourceIndexPath.row - 1] //Get the item that we just moved
-//        locationList.remove(at: sourceIndexPath.row - 1) // Remove the item from the array
-//        locationList.insert(itemMove, at: destinationIndexPath.row) //Re-insert back into array
-//        CoreDataManager.shared.getLocationSequence(locationList: locationList)
-//
-//        let itemMove2 = weatherData[sourceIndexPath.row]
-//        weatherData.remove(at: sourceIndexPath.row)
-//        weatherData.insert(itemMove2, at: destinationIndexPath.row)
-//        exchangeLocationIndex.onNext([sourceIndexPath.row, destinationIndexPath.row])
-//    }
+    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+
+        // +1로 해줘야할듯
+        let itemMove = locationList[sourceIndexPath.row - 1] //Get the item that we just moved
+        locationList.remove(at: sourceIndexPath.row - 1) // Remove the item from the array
+        locationList.insert(itemMove, at: destinationIndexPath.row - 1) //Re-insert back into array
+        CoreDataManager.shared.getLocationSequence(locationList: locationList)
+
+        let itemMove2 = weatherData[sourceIndexPath.row]
+        weatherData.remove(at: sourceIndexPath.row)
+        weatherData.insert(itemMove2, at: destinationIndexPath.row)
+        exchangeLocationIndex.onNext([sourceIndexPath.row, destinationIndexPath.row])
+    }
     
     func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
         if session.localDragSession != nil {

--- a/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
+++ b/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
@@ -123,9 +123,9 @@ class CheckWeatherView: UIViewController {
         var weatherData = [Weather](repeating: FetchWeatherInformation().dummyData, count: locations.count + 1)
         weatherData[0] = initialWeathers[0]
         for weatherIndex in 1..<initialWeathers.count {
-            for index in 0..<locations.count {
-                if initialWeathers[weatherIndex].localWeather[0].localCode == locations[index].code {
-                    weatherData[index + 1] = initialWeathers[weatherIndex]
+            for locationIndex in 0..<locations.count {
+                if initialWeathers[weatherIndex].localWeather[0].localCode == locations[locationIndex].code {
+                    weatherData[locationIndex + 1] = initialWeathers[weatherIndex]
                     continue
                 }
             }

--- a/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
+++ b/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
@@ -26,7 +26,6 @@ class CheckWeatherView: UIViewController {
     lazy var cityData = self.cityInformationModel.loadCityListFromCSV()
     var locationList = CoreDataManager.shared.fetchLocations()
     
-    var weathers = [Weather]()
     
     lazy var pageViewController: UIPageViewController = {
         let vc = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
@@ -37,8 +36,9 @@ class CheckWeatherView: UIViewController {
     
     var dataViewControllers = [UIViewController]()
     
+    var weathers = [Weather]()
+    var initialWeathers = [Weather]()
     var locations = [Location]()
-    var updateWeathers = [Weather]()
     weak var delegate: LocationSelectionDelegate?
     
     override func viewWillAppear(_ animated: Bool) {
@@ -82,12 +82,9 @@ class CheckWeatherView: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-//        let appDelegate = UIApplication.shared.delegate as? AppDelegate
-//        if let weathers = appDelegate?.weathers {
-//            self.weathers = weathers
-//            self.updateWeathers = weathers
-//        }
         bind()
+        locations = CoreDataManager.shared.fetchLocations()
+        self.weathers = serializeLocationSequence(locations: locations, initialWeathers: initialWeathers)
         self.delegate = self.locationSelectionView
         // 스와이프로 pop되어서 런치스크린으로 가는 것을 막아줍니다.
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
@@ -120,6 +117,20 @@ class CheckWeatherView: UIViewController {
                 self.weathers.insert(itemMove, at: $0[1])
             })
             .disposed(by: disposeBag)
+    }
+    
+    private func serializeLocationSequence(locations: [Location], initialWeathers: [Weather]) -> [Weather] {
+        var weatherData = [Weather](repeating: FetchWeatherInformation().dummyData, count: locations.count + 1)
+        weatherData[0] = initialWeathers[0]
+        for weatherIndex in 1..<initialWeathers.count {
+            for index in 0..<locations.count {
+                if initialWeathers[weatherIndex].localWeather[0].localCode == locations[index].code {
+                    weatherData[index + 1] = initialWeathers[weatherIndex]
+                    continue
+                }
+            }
+        }
+        return weatherData
     }
     
     func loadWeatherView() {


### PR DESCRIPTION
### Motivation 
- #319 

### Key Change
- 기존에는 Location 의 기상 데이터를 모두 요청하고 불러오는데 3초가 걸리지 않는다는 가정 하에 임시 방편으로 3초 후 메인 화면으로 이동하도록 구현했었습니다. 이를 개선하고자 Location 의 기상 정보가 다 불러왔을 때 메인 화면으로 넘어가도록 구현하였습니다.
- LocationSelectionView 에서 Location 위치를 수정할 경우 메인 화면인 CheckWeatherView 에도 반영되도록 하였습니다.

|데이터 불러오면 이동|위치 수정|
|---|---|
|![Simulator Screen Recording - iPhone 14 Pro - 2022-11-26 at 16 32 53](https://user-images.githubusercontent.com/86882798/204077727-9219af01-51d6-4ee4-b2b1-3df26f57774f.gif)|![Simulator Screen Recording - iPhone 14 Pro - 2022-11-26 at 16 34 21](https://user-images.githubusercontent.com/86882798/204077734-afb1e428-0300-4952-949d-9fbc3e6d0b39.gif)|




### To Reviewer
- 유저의 위치 정보가 동의했을 때에 대한 데이터 요청은 유저에게 현재 위치를 요청하는 시점에 대한 기획이 확정된 후 반영하도록 하겠습니다.
