### PR TITLE
Feat[#324] : 지역 추가/삭제/위치 이동 시 발생하는 이슈 개선 및 현재 위치 동의 여부에 따른 지역 Cell 분기 처리

### DIFF
--- a/Kloudy/Kloudy/CoreData/CoreDataManager.swift
+++ b/Kloudy/Kloudy/CoreData/CoreDataManager.swift
@@ -115,11 +115,6 @@ class CoreDataManager {
             (location as! Location).addToWeatherCell(cellObject)
         }
     }
-    // 지역을 삭제
-    func locationDelete(location: NSManagedObject) {
-        coreDataStack.managedContext.delete(location)
-        coreDataStack.saveContext()
-    }
     
     func deleteLocation(location: Location){
         let request = NSFetchRequest<Location>(entityName: "Location")

--- a/Kloudy/Kloudy/CoreData/CoreDataManager.swift
+++ b/Kloudy/Kloudy/CoreData/CoreDataManager.swift
@@ -65,9 +65,9 @@ class CoreDataManager {
         do {
             let locations = try coreDataStack.managedContext.fetch(request)
             for i in 0..<locations.count {
-                locations[i].setValue(locationList[i].code, forKey: "code")
-                locations[i].setValue(locationList[i].city, forKey: "city")
-                locations[i].setValue(locationList[i].province, forKey: "province")
+                locations[i].code = locationList[i].code
+                locations[i].city = locationList[i].city
+                locations[i].province = locationList[i].province
             }
             coreDataStack.saveContext()
         } catch {

--- a/Kloudy/Kloudy/CoreData/CoreDataManager.swift
+++ b/Kloudy/Kloudy/CoreData/CoreDataManager.swift
@@ -120,4 +120,20 @@ class CoreDataManager {
         coreDataStack.managedContext.delete(location)
         coreDataStack.saveContext()
     }
+    
+    func deleteLocation(location: Location){
+        let request = NSFetchRequest<Location>(entityName: "Location")
+        do {
+            var locations = try coreDataStack.managedContext.fetch(request)
+            for locationIndex in locations.indices {
+                if locations[locationIndex].code == location.code {
+                    self.coreDataStack.managedContext.delete(location)
+                    break
+                }
+            }
+        } catch {
+            print("-----SameLocationsError-----")
+        }
+        coreDataStack.saveContext()
+    }
 }

--- a/Kloudy/Kloudy/CoreData/CoreDataManager.swift
+++ b/Kloudy/Kloudy/CoreData/CoreDataManager.swift
@@ -65,9 +65,9 @@ class CoreDataManager {
         do {
             let locations = try coreDataStack.managedContext.fetch(request)
             for i in 0..<locations.count {
-                locations[i].code = locationList[i].code
-                locations[i].city = locationList[i].city
-                locations[i].province = locationList[i].province
+                locations[i].setValue(locationList[i].code, forKey: "code")
+                locations[i].setValue(locationList[i].city, forKey: "city")
+                locations[i].setValue(locationList[i].province, forKey: "province")
             }
             coreDataStack.saveContext()
         } catch {

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
@@ -30,8 +30,6 @@ class CurrentLocationTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         addView()
         setLayout()
-//        self.locationManager.delegate = self
-//        agreeButton.addTarget(self, action: #selector(authorizeGPS), for: .touchUpInside)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -85,21 +83,5 @@ class CurrentLocationTableViewCell: UITableViewCell {
         contentView.backgroundColor = UIColor.KColor.white
         contentView.layer.cornerRadius = contentView.frame.height / 5
         contentView.layer.applySketchShadow(color: UIColor.KColor.gray02, alpha: 0.1, x: 0, y: 0, blur: 40, spread: 0)
-    }
-}
-
-extension CurrentLocationTableViewCell: CLLocationManagerDelegate {
-    @objc func authorizeGPS() {
-        let currentStatus = CLLocationManager().authorizationStatus
-        
-        if currentStatus == .notDetermined {
-            self.locationManager.requestAlwaysAuthorization()
-        } else if currentStatus == .restricted || currentStatus == .denied {
-            if let appSettings = URL(string: UIApplication.openSettingsURLString) {
-                UIApplication.shared.open(appSettings, options: [:], completionHandler: nil)
-            }
-        } else {
-            print("--exception--")
-        }
     }
 }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
@@ -81,11 +81,8 @@ class CurrentLocationTableViewCell: UITableViewCell {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        contentView.backgroundColor = UIColor.KColor.white
         contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8))
-        
         contentView.layer.cornerRadius = contentView.frame.height / 5
-        
         contentView.layer.applySketchShadow(color: UIColor.KColor.gray02, alpha: 0.1, x: 0, y: 0, blur: 40, spread: 0)
     }
 }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/CurrentLocationTableViewCell.swift
@@ -30,8 +30,8 @@ class CurrentLocationTableViewCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         addView()
         setLayout()
-        self.locationManager.delegate = self
-        agreeButton.addTarget(self, action: #selector(authorizeGPS), for: .touchUpInside)
+//        self.locationManager.delegate = self
+//        agreeButton.addTarget(self, action: #selector(authorizeGPS), for: .touchUpInside)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -82,6 +82,7 @@ class CurrentLocationTableViewCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8))
+        contentView.backgroundColor = UIColor.KColor.white
         contentView.layer.cornerRadius = contentView.frame.height / 5
         contentView.layer.applySketchShadow(color: UIColor.KColor.gray02, alpha: 0.1, x: 0, y: 0, blur: 40, spread: 0)
     }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/LocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/LocationTableViewCell.swift
@@ -81,6 +81,7 @@ class LocationTableViewCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8))
+        contentView.backgroundColor = UIColor.KColor.white
         contentView.layer.cornerRadius = contentView.frame.height / 5
         contentView.layer.applySketchShadow(color: UIColor.KColor.gray02, alpha: 0.1, x: 0, y: 0, blur: 40, spread: 0)
     }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/LocationTableViewCell.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionCollectionViewCell/LocationTableViewCell.swift
@@ -80,11 +80,8 @@ class LocationTableViewCell: UITableViewCell {
     
     override func layoutSubviews() {
         super.layoutSubviews()
-        contentView.backgroundColor = UIColor.KColor.white
         contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8))
-        
         contentView.layer.cornerRadius = contentView.frame.height / 5
-        
         contentView.layer.applySketchShadow(color: UIColor.KColor.gray02, alpha: 0.1, x: 0, y: 0, blur: 40, spread: 0)
     }
 }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -315,7 +315,6 @@ extension LocationSelectionView: UITableViewDataSource {
         switch tableType {
         case .search:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: "SearchLocationCell", for: indexPath) as? SearchLocationCell else { return UITableViewCell() }
-            // snapkit remakeConstraint 처리 유무 체크 필요
             let searchingLocation = filteredSearchTableTypeData[indexPath.row]
             cell.locationLabel.text = searchingLocation.locationString
             return cell
@@ -373,9 +372,9 @@ extension LocationSelectionView: UITableViewDataSource {
         case .check:
             if indexPath.row != 0 {
                 let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
-                    self.deleteLocationCode.onNext(self.locationFromCoreData[indexPath.row - 1].code ?? "")
-                    CoreDataManager.shared.locationDelete(location: self.locationFromCoreData[indexPath.row - 1])
+                    self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
                     self.weatherData.remove(at: indexPath.row)
+                    CoreDataManager.shared.locationDelete(location: self.locationFromCoreData[indexPath.row - 1])
                     tableView.deleteRows(at: [indexPath], with: .fade)
                     completionHandler(true)
                 }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -405,6 +405,8 @@ extension LocationSelectionView: UITableViewDelegate {
                 if information.code == searchingLocation.locationCode {
                     if CoreDataManager.shared.checkLocationIsSame(locationCode: searchingLocation.locationCode) {
                         CoreDataManager.shared.saveLocation(code: information.code, city: information.city, province: information.province, sequence: CoreDataManager.shared.countLocations(), indexArray: defaultIndexArray)
+                        self.locationList.append(LocationData(code: information.code, city: information.city, province: information.province))
+                        
                         self.changeTableType(false)
                         self.weatherData.append(FetchWeatherInformation().dummyData)
                         CityWeatherNetwork().fetchCityWeather(code: information.code)

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -46,6 +46,9 @@ class LocationSelectionView: UIViewController {
     let deleteLocationCode = PublishSubject<String>()
     let exchangeLocationIndex = PublishSubject<[Int]>()
     
+    // 지역 동의 버튼
+    let authorizeButtonTapped = PublishRelay<Void>()
+    
     // delegate 로 전달 받는 Weather Data
     var weatherData = [Weather]()
     
@@ -331,8 +334,11 @@ extension LocationSelectionView: UITableViewDataSource {
                     guard let cell = tableView.dequeueReusableCell(withIdentifier: "currentCell", for: indexPath) as? CurrentLocationTableViewCell else {
                         return UITableViewCell() }
                     cell.locationNameLabel.text = "현재 위치"
+                    cell.agreeButton.rx.tap
+                        .asObservable()
+                        .bind(to: authorizeButtonTapped)
+                        .disposed(by: disposeBag)
                     cell.backgroundColor = UIColor.KColor.clear
-                    cell.contentView.backgroundColor = UIColor.KColor.gray04
                     cell.selectionStyle = .none
                     return cell
                 } else {
@@ -343,7 +349,6 @@ extension LocationSelectionView: UITableViewDataSource {
                     cell.temperatureLabel.text = String(Int(weatherData[indexPath.row].localWeather[0].hourlyWeather[2].temperature)) + "°"
                     cell.diurnalTemperatureLabel.text = "\(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[2]))° | \(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[1]))°"
                     cell.backgroundColor = UIColor.KColor.clear
-                    cell.contentView.backgroundColor = UIColor.KColor.gray04
                     cell.selectionStyle = .none
                     return cell
                 }
@@ -355,7 +360,6 @@ extension LocationSelectionView: UITableViewDataSource {
                 cell.temperatureLabel.text = String(Int(weatherData[indexPath.row].localWeather[0].hourlyWeather[2].temperature)) + "°"
                 cell.diurnalTemperatureLabel.text = "\(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[2]))° | \(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[1]))°"
                 cell.backgroundColor = UIColor.KColor.clear
-                cell.contentView.backgroundColor = UIColor.KColor.white
                 cell.selectionStyle = .none
                 return cell
             }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -332,6 +332,7 @@ extension LocationSelectionView: UITableViewDataSource {
                         return UITableViewCell() }
                     cell.locationNameLabel.text = "현재 위치"
                     cell.backgroundColor = UIColor.KColor.clear
+                    cell.contentView.backgroundColor = UIColor.KColor.gray04
                     cell.selectionStyle = .none
                     return cell
                 } else {
@@ -342,6 +343,7 @@ extension LocationSelectionView: UITableViewDataSource {
                     cell.temperatureLabel.text = String(Int(weatherData[indexPath.row].localWeather[0].hourlyWeather[2].temperature)) + "°"
                     cell.diurnalTemperatureLabel.text = "\(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[2]))° | \(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[1]))°"
                     cell.backgroundColor = UIColor.KColor.clear
+                    cell.contentView.backgroundColor = UIColor.KColor.gray04
                     cell.selectionStyle = .none
                     return cell
                 }
@@ -353,6 +355,7 @@ extension LocationSelectionView: UITableViewDataSource {
                 cell.temperatureLabel.text = String(Int(weatherData[indexPath.row].localWeather[0].hourlyWeather[2].temperature)) + "°"
                 cell.diurnalTemperatureLabel.text = "\(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[2]))° | \(Int(weatherData[indexPath.row].localWeather[0].minMaxTemperature()[1]))°"
                 cell.backgroundColor = UIColor.KColor.clear
+                cell.contentView.backgroundColor = UIColor.KColor.white
                 cell.selectionStyle = .none
                 return cell
             }
@@ -376,27 +379,53 @@ extension LocationSelectionView: UITableViewDataSource {
             return nil
         case .check:
             if indexPath.row != 0 {
-                let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
-                    
-                    CoreDataManager.shared.deleteLocation(location: self.locationFromCoreData[indexPath.row - 1])
-                    self.locationFromCoreData = CoreDataManager.shared.fetchLocations()
-                    
-                    self.locationList.remove(at: indexPath.row - 1)
-                    
-                    self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
-                    print("\(self.weatherData[indexPath.row].localWeather[0].localName)🐳")
-                    self.weatherData.remove(at: indexPath.row)
-                    tableView.deleteRows(at: [indexPath], with: .fade)
-                    completionHandler(true)
-                }
-                
-                deleteAction.image = UIGraphicsImageRenderer(size: CGSize(width: 50, height: 93)).image { _ in
-                    UIImage(named: "deleteButton")?.draw(in: CGRect(x: 0, y: 3.8, width: 50, height: 86))
-                }
+                if currentStatus == .notDetermined || currentStatus == .restricted || currentStatus == .denied {
+                    if indexPath.row != 1 {
+                        let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
+                            
+                            CoreDataManager.shared.deleteLocation(location: self.locationFromCoreData[indexPath.row - 1])
+                            self.locationFromCoreData = CoreDataManager.shared.fetchLocations()
+                            
+                            self.locationList.remove(at: indexPath.row - 1)
+                            
+                            self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
+                            self.weatherData.remove(at: indexPath.row)
+                            tableView.deleteRows(at: [indexPath], with: .fade)
+                            completionHandler(true)
+                        }
+                        
+                        deleteAction.image = UIGraphicsImageRenderer(size: CGSize(width: 50, height: 93)).image { _ in
+                            UIImage(named: "deleteButton")?.draw(in: CGRect(x: 0, y: 3.8, width: 50, height: 86))
+                        }
 
-                deleteAction.backgroundColor = .systemBackground
-                let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
-                return configuration
+                        deleteAction.backgroundColor = .systemBackground
+                        let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
+                        return configuration
+                    } else {
+                        return nil
+                    }
+                } else {
+                    let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
+                        
+                        CoreDataManager.shared.deleteLocation(location: self.locationFromCoreData[indexPath.row - 1])
+                        self.locationFromCoreData = CoreDataManager.shared.fetchLocations()
+                        
+                        self.locationList.remove(at: indexPath.row - 1)
+                        
+                        self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
+                        self.weatherData.remove(at: indexPath.row)
+                        tableView.deleteRows(at: [indexPath], with: .fade)
+                        completionHandler(true)
+                    }
+                    
+                    deleteAction.image = UIGraphicsImageRenderer(size: CGSize(width: 50, height: 93)).image { _ in
+                        UIImage(named: "deleteButton")?.draw(in: CGRect(x: 0, y: 3.8, width: 50, height: 86))
+                    }
+
+                    deleteAction.backgroundColor = .systemBackground
+                    let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
+                    return configuration
+                }
             } else {
                 return nil
             }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -385,55 +385,42 @@ extension LocationSelectionView: UITableViewDataSource {
             if indexPath.row != 0 {
                 if currentStatus == .notDetermined || currentStatus == .restricted || currentStatus == .denied {
                     if indexPath.row != 1 {
-                        let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
-                            
-                            CoreDataManager.shared.deleteLocation(location: self.locationFromCoreData[indexPath.row - 1])
-                            self.locationFromCoreData = CoreDataManager.shared.fetchLocations()
-                            
-                            self.locationList.remove(at: indexPath.row - 1)
-                            
-                            self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
-                            self.weatherData.remove(at: indexPath.row)
-                            tableView.deleteRows(at: [indexPath], with: .fade)
-                            completionHandler(true)
-                        }
-                        
-                        deleteAction.image = UIGraphicsImageRenderer(size: CGSize(width: 50, height: 93)).image { _ in
-                            UIImage(named: "deleteButton")?.draw(in: CGRect(x: 0, y: 3.8, width: 50, height: 86))
-                        }
-
-                        deleteAction.backgroundColor = .systemBackground
-                        let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
+                        let configuration = UISwipeActionsConfiguration(actions: [deleteLocation(indexPath: indexPath)])
                         return configuration
                     } else {
                         return nil
                     }
                 } else {
-                    let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
-                        
-                        CoreDataManager.shared.deleteLocation(location: self.locationFromCoreData[indexPath.row - 1])
-                        self.locationFromCoreData = CoreDataManager.shared.fetchLocations()
-                        
-                        self.locationList.remove(at: indexPath.row - 1)
-                        
-                        self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
-                        self.weatherData.remove(at: indexPath.row)
-                        tableView.deleteRows(at: [indexPath], with: .fade)
-                        completionHandler(true)
-                    }
-                    
-                    deleteAction.image = UIGraphicsImageRenderer(size: CGSize(width: 50, height: 93)).image { _ in
-                        UIImage(named: "deleteButton")?.draw(in: CGRect(x: 0, y: 3.8, width: 50, height: 86))
-                    }
-
-                    deleteAction.backgroundColor = .systemBackground
-                    let configuration = UISwipeActionsConfiguration(actions: [deleteAction])
+                    let configuration = UISwipeActionsConfiguration(actions: [deleteLocation(indexPath: indexPath)])
                     return configuration
                 }
             } else {
                 return nil
             }
         }
+    }
+    
+    private func deleteLocation(indexPath: IndexPath) -> UIContextualAction {
+        let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
+            
+            CoreDataManager.shared.deleteLocation(location: self.locationFromCoreData[indexPath.row - 1])
+            self.locationFromCoreData = CoreDataManager.shared.fetchLocations()
+            
+            self.locationList.remove(at: indexPath.row - 1)
+            
+            self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
+            self.weatherData.remove(at: indexPath.row)
+            self.tableView.deleteRows(at: [indexPath], with: .fade)
+            completionHandler(true)
+        }
+        
+        deleteAction.image = UIGraphicsImageRenderer(size: CGSize(width: 50, height: 93)).image { _ in
+            UIImage(named: "deleteButton")?.draw(in: CGRect(x: 0, y: 3.8, width: 50, height: 86))
+        }
+
+        deleteAction.backgroundColor = .systemBackground
+        
+        return deleteAction
     }
 }
 

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -77,6 +77,11 @@ class LocationSelectionView: UIViewController {
         inputLocationCellData()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        locationFromCoreData = []
+    }
+    
     // https://github.com/PLREQ/PLREQ
     func inputLocationCellData() {
         locationList = []
@@ -372,9 +377,15 @@ extension LocationSelectionView: UITableViewDataSource {
         case .check:
             if indexPath.row != 0 {
                 let deleteAction = UIContextualAction(style: .destructive, title: nil) { _, _, completionHandler in
+                    
+                    CoreDataManager.shared.deleteLocation(location: self.locationFromCoreData[indexPath.row - 1])
+                    self.locationFromCoreData = CoreDataManager.shared.fetchLocations()
+                    
+                    self.locationList.remove(at: indexPath.row - 1)
+                    
                     self.deleteLocationCode.onNext(self.weatherData[indexPath.row].localWeather[0].localCode)
+                    print("\(self.weatherData[indexPath.row].localWeather[0].localName)🐳")
                     self.weatherData.remove(at: indexPath.row)
-                    CoreDataManager.shared.locationDelete(location: self.locationFromCoreData[indexPath.row - 1])
                     tableView.deleteRows(at: [indexPath], with: .fade)
                     completionHandler(true)
                 }

--- a/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
+++ b/Kloudy/Kloudy/View/CheckLocation/LocationSelectionView/LocationSelectionView.swift
@@ -458,7 +458,7 @@ extension LocationSelectionView: UITableViewDelegate {
 
 extension LocationSelectionView: UITableViewDragDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-            return [UIDragItem(itemProvider: NSItemProvider())]
+        return [UIDragItem(itemProvider: NSItemProvider())]
     }
 }
 
@@ -483,8 +483,8 @@ extension LocationSelectionView: UITableViewDropDelegate {
     
     // 셀 위치 변경 함수
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-
-        // +1로 해줘야할듯
+        guard sourceIndexPath.row != 0 else { return }
+        
         let itemMove = locationList[sourceIndexPath.row - 1] //Get the item that we just moved
         locationList.remove(at: sourceIndexPath.row - 1) // Remove the item from the array
         locationList.insert(itemMove, at: destinationIndexPath.row - 1) //Re-insert back into array

--- a/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
+++ b/Kloudy/Kloudy/View/CheckWeather/CheckWeatherView/CheckWeatherView.swift
@@ -18,6 +18,7 @@ class CheckWeatherView: UIViewController {
     let disposeBag = DisposeBag()
     let checkWeatherBasicNavigationView = CheckWeatherBasicNavigationView()
     let locationSelectionView = LocationSelectionView()
+    let settingView = SettingView()
     
     let pageControl = UIPageControl()
     let initialPage = 0
@@ -115,6 +116,13 @@ class CheckWeatherView: UIViewController {
                 let itemMove = self.weathers[$0[0]]
                 self.weathers.remove(at: $0[0])
                 self.weathers.insert(itemMove, at: $0[1])
+            })
+            .disposed(by: disposeBag)
+        
+        locationSelectionView.authorizeButtonTapped
+            .subscribe(onNext: {
+                self.locationSelectionView.navigationController?.popViewController(animated: true)
+                self.navigationController?.pushViewController(self.settingView, animated: true)
             })
             .disposed(by: disposeBag)
     }
@@ -275,7 +283,6 @@ class CheckWeatherView: UIViewController {
         self.delegate?.sendWeatherData(weatherData: weathers)
     }
     @objc func tapSettingButton() {
-        let settingView = SettingView()
         self.navigationController?.pushViewController(settingView, animated: true)
     }
     


### PR DESCRIPTION
### Motivation 
- #324 

### Key Change
- 지역 추가/삭제/위치 이동 시 발생하는 에러를 최종적으로 해결하였습니다. (진짜 마지막 🙏🏻)
- 유저가 현재 위치 정보 수집에 동의하지 않은 경우, 첫번째 Cell 의 삭제가 불가능하도록 설정하고, "위치 동의 >" 버튼을 눌렀을 시 설정 뷰로 이동하도록 구현하였습니다.

|추가/삭제/위치이동|위치 정보 수집 X|
|---|---|
|![Simulator Screen Recording - iPhone 14 Pro - 2022-11-27 at 22 23 23](https://user-images.githubusercontent.com/86882798/204137702-e6e922a7-b4b7-4e11-90dd-ef3801cd9294.gif)|![Simulator Screen Recording - iPhone 14 Pro - 2022-11-27 at 22 25 52](https://user-images.githubusercontent.com/86882798/204137773-4b78a0b3-8139-4843-8794-4ea87bfc73f6.gif)|

### To Reviewer
- 위치 정보 수집 동의 Alert 를 언제 유저에게 보낼지, 그리고 동의했을 때 언제 유저의 현재 위치에 대한 기상정보를 요청할지 이야기해봐용
